### PR TITLE
New dock

### DIFF
--- a/addons/very-simple-twitch/chat/vst_chat_dock.gd
+++ b/addons/very-simple-twitch/chat/vst_chat_dock.gd
@@ -48,22 +48,33 @@ var disconnect_button:Button:
 		return disconnect_button
 	
 func _on_button_pressed():
-	twitch_chat.OnSucess.connect(onChatConnected)
+	twitch_chat.OnSucess.connect(on_chat_connected)
 	twitch_chat.OnMessage.connect(create_chatter_msg)
-	twitch_chat.OnFailure.connect(onError)
+	twitch_chat.OnFailure.connect(on_error)
 	
 	twitch_chat.login_anon(channel_line_edit.text)
 	connect_button.disabled = true
 	channel_line_edit.editable = false
 
+func _on_clear_button_pressed():
+	clear_all_messages()
+	
 func _on_line_edit_text_changed(new_text):
 	connect_button.disabled = len(new_text) == 0
 
-func onChatConnected():
-	create_system_msg("Connected to Chat")
+func _on_disconnect_button_pressed():
+	# TODO: Ok, It's too much removing the node and placing another. Change it when logout method is available
+	twitch_chat.queue_free()
+	twitch_chat = null
+	
+	clear_all_messages()
+	show_connect_layout()
+	
+func on_chat_connected():
+	create_system_msg("Connected to chat")
 	show_chat_layout()
 
-func onError():
+func on_error():
 	create_system_msg("Failed to connect into chat")
 	connect_button.disabled = false
 	channel_line_edit.editable = true
@@ -73,7 +84,6 @@ func create_system_msg(message: String):
 	msg.set_chatter_string("[i]"+message+"[/i]")
 	chat_layout.add_child(msg)
 	check_scroll()
-
 
 func create_chatter_msg(chatter: Chatter):
 	var msg = line.instantiate()
@@ -129,34 +139,9 @@ func is_scroll_bottom() -> bool:
 func escape_bbcode(bbcode_text) -> String:
 	return bbcode_text.replace("[", "[lb]")
 
-class EmoteLocation extends RefCounted:
-	var id : String
-	var start : int
-	var end : int
-
-	func _init(emote_id, start_idx, end_idx):
-		self.id = emote_id
-		self.start = start_idx
-		self.end = end_idx
-
-	static func smaller(a: EmoteLocation, b: EmoteLocation):
-		return a.start < b.start
-
-
-func _on_clear_button_pressed():
-	clear_all_messages()
-
 func clear_all_messages():
 	for childen in chat_layout.get_children():
 		chat_layout.remove_child(childen)
-
-func _on_disconnect_button_pressed():
-	# TODO: Ok, It's too much removing the node and placing another. Change it when logout method is available
-	twitch_chat.queue_free()
-	twitch_chat = null
-	
-	clear_all_messages()
-	show_connect_layout()
 
 func show_chat_layout():
 	disconnect_button.visible = true
@@ -171,4 +156,16 @@ func show_connect_layout():
 	channel_line_edit.visible = true
 	connect_button.visible = true
 	connect_button.disabled = false
-	
+
+class EmoteLocation extends RefCounted:
+	var id : String
+	var start : int
+	var end : int
+
+	func _init(emote_id, start_idx, end_idx):
+		self.id = emote_id
+		self.start = start_idx
+		self.end = end_idx
+
+	static func smaller(a: EmoteLocation, b: EmoteLocation):
+		return a.start < b.start

--- a/addons/very-simple-twitch/chat/vst_chat_dock.gd
+++ b/addons/very-simple-twitch/chat/vst_chat_dock.gd
@@ -1,0 +1,174 @@
+@tool
+extends Control
+
+const MAX_MESSAGES:int = 50
+var line:PackedScene = load("res://addons/very-simple-twitch/chat/vst_chat_dock_line.tscn")
+
+var twitch_chat: TwitchChat:
+	get:
+		if twitch_chat == null:
+			twitch_chat = TwitchChat.new()
+			add_child(twitch_chat)
+		return twitch_chat
+
+var channel_line_edit: LineEdit:
+	get:
+		if channel_line_edit == null:
+			channel_line_edit = $VBoxContainer/HBoxContainer/LineEdit
+		return channel_line_edit
+
+var connect_button: Button:
+	get:
+		if connect_button == null:
+			connect_button = $VBoxContainer/HBoxContainer/ConnectButton
+		return connect_button
+	
+var chat_layout: Control:
+	get:
+		if chat_layout == null:
+			chat_layout = $VBoxContainer/VBoxContainer/Chat/ScrollContainer/ChatMessageContainer
+		return chat_layout
+	
+var chat_scroll:ScrollContainer:
+	get:
+		if chat_scroll == null:
+			chat_scroll = $VBoxContainer/VBoxContainer/Chat/ScrollContainer
+		return chat_scroll
+
+var clear_button:Button:
+	get:
+		if clear_button == null:
+			clear_button = $VBoxContainer/HBoxContainer/ClearButton
+		return clear_button
+
+var disconnect_button:Button:
+	get:
+		if disconnect_button == null:
+			disconnect_button = $VBoxContainer/HBoxContainer/DisconnectButton
+		return disconnect_button
+	
+func _on_button_pressed():
+	twitch_chat.OnSucess.connect(onChatConnected)
+	twitch_chat.OnMessage.connect(create_chatter_msg)
+	twitch_chat.OnFailure.connect(onError)
+	
+	twitch_chat.login_anon(channel_line_edit.text)
+	connect_button.disabled = true
+	channel_line_edit.editable = false
+
+func _on_line_edit_text_changed(new_text):
+	connect_button.disabled = len(new_text) == 0
+
+func onChatConnected():
+	create_system_msg("Connected to Chat")
+	show_chat_layout()
+
+func onError():
+	create_system_msg("Failed to connect into chat")
+	connect_button.disabled = false
+	channel_line_edit.editable = true
+
+func create_system_msg(message: String):
+	var msg = line.instantiate()
+	msg.set_chatter_string("[i]"+message+"[/i]")
+	chat_layout.add_child(msg)
+	check_scroll()
+
+
+func create_chatter_msg(chatter: Chatter):
+	var msg = line.instantiate()
+	
+	var badges: String = await get_badges(chatter)
+	chatter.message = escape_bbcode(chatter.message)
+	await add_emotes(chatter)
+
+	msg.set_chatter_msg(badges, chatter)
+	chat_layout.add_child(msg)
+	
+	check_scroll()
+
+func check_scroll():
+	var bottom: bool = is_scroll_bottom()
+	check_number_messages()
+	await get_tree().process_frame
+	if bottom: chat_scroll.scroll_vertical = chat_scroll.get_v_scroll_bar().max_value
+
+func check_number_messages():
+	if chat_layout.get_child_count() > MAX_MESSAGES:
+		chat_layout.remove_child(chat_layout.get_children()[0])
+
+func get_badges(chatter: Chatter) -> String:
+	var badges:= ""
+	for badge in chatter.tags.badges:
+		var result = await twitch_chat.get_badge(badge, chatter.tags.badges[badge], chatter.tags.user_id) 
+		if result:
+			badges += "[img=center]" + result.resource_path + "[/img] "
+	return badges
+	
+func add_emotes(chatter: Chatter):
+	if chatter.tags.emotes.is_empty(): return
+
+	var locations: Array = []
+	for emote in chatter.tags.emotes:
+		for data in chatter.tags.emotes[emote].split(","):
+			var start_end = data.split("-")
+			locations.append(EmoteLocation.new(emote, int(start_end[0]), int(start_end[1])))
+
+	locations.sort_custom(Callable(EmoteLocation, "smaller"))
+	var offset = 0
+	for loc in locations:
+		var result = await twitch_chat.get_emote(loc.id)
+		var emote_string = "[img=center]" + result.resource_path +"[/img]"
+		chatter.message = chatter.message.substr(0, loc.start + offset) + emote_string + chatter.message.substr(loc.end + offset + 1)
+		offset += emote_string.length() + loc.start - loc.end - 1
+	
+func is_scroll_bottom() -> bool:
+	return chat_scroll.scroll_vertical == chat_scroll.get_v_scroll_bar().max_value - chat_scroll.get_v_scroll_bar().get_rect().size.y
+
+# Returns escaped BBCode that won't be parsed by RichTextLabel as tags.
+func escape_bbcode(bbcode_text) -> String:
+	return bbcode_text.replace("[", "[lb]")
+
+class EmoteLocation extends RefCounted:
+	var id : String
+	var start : int
+	var end : int
+
+	func _init(emote_id, start_idx, end_idx):
+		self.id = emote_id
+		self.start = start_idx
+		self.end = end_idx
+
+	static func smaller(a: EmoteLocation, b: EmoteLocation):
+		return a.start < b.start
+
+
+func _on_clear_button_pressed():
+	clear_all_messages()
+
+func clear_all_messages():
+	for childen in chat_layout.get_children():
+		chat_layout.remove_child(childen)
+
+func _on_disconnect_button_pressed():
+	# TODO: Ok, It's too much removing the node and placing another. Change it when logout method is available
+	twitch_chat.queue_free()
+	twitch_chat = null
+	
+	clear_all_messages()
+	show_connect_layout()
+
+func show_chat_layout():
+	disconnect_button.visible = true
+	clear_button.visible = true
+	channel_line_edit.visible = false
+	connect_button.visible = false
+	
+func show_connect_layout():
+	disconnect_button.visible = false
+	clear_button.visible = false
+	channel_line_edit.editable = true
+	channel_line_edit.visible = true
+	connect_button.visible = true
+	connect_button.disabled = false
+	

--- a/addons/very-simple-twitch/chat/vst_chat_dock.tscn
+++ b/addons/very-simple-twitch/chat/vst_chat_dock.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=2 format=3 uid="uid://c8jard0jvmfmt"]
+
+[ext_resource type="Script" path="res://addons/very-simple-twitch/chat/vst_chat_dock.gd" id="1_fkddh"]
+
+[node name="VstChatDock" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_fkddh")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="LineEdit" type="LineEdit" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Channel name"
+
+[node name="ConnectButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+disabled = true
+text = "CONNECT"
+
+[node name="ClearButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+visible = false
+layout_mode = 2
+text = "CLEAR CHAT"
+
+[node name="DisconnectButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+visible = false
+layout_mode = 2
+text = "DISCONNECT"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Chat" type="Panel" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/VBoxContainer/Chat"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ChatMessageContainer" type="VBoxContainer" parent="VBoxContainer/VBoxContainer/Chat/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/LineEdit" to="." method="_on_line_edit_text_changed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/ConnectButton" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/ClearButton" to="." method="_on_clear_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/DisconnectButton" to="." method="_on_disconnect_button_pressed"]

--- a/addons/very-simple-twitch/chat/vst_chat_dock_line.gd
+++ b/addons/very-simple-twitch/chat/vst_chat_dock_line.gd
@@ -1,0 +1,9 @@
+@tool
+extends HBoxContainer
+
+func set_chatter_msg(badges: String, chatter: Chatter):
+	set_chatter_string("%02d:%02d" %[chatter.date_time_dict["hour"], chatter.date_time_dict["minute"]] + " " + badges + " [b][color="+ chatter.tags.color_hex + "]" +chatter.tags.display_name +"[/color][/b]: " + chatter.message)
+
+func set_chatter_string(message:String):
+	$RichTextLabel.text = message
+	queue_sort()

--- a/addons/very-simple-twitch/chat/vst_chat_dock_line.tscn
+++ b/addons/very-simple-twitch/chat/vst_chat_dock_line.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3 uid="uid://bo1un8cwcrpqr"]
+
+[ext_resource type="Script" path="res://addons/very-simple-twitch/chat/vst_chat_dock_line.gd" id="1_h0lnd"]
+
+[node name="VstChatDockLine" type="HBoxContainer"]
+offset_right = 1.0
+offset_bottom = 115.0
+size_flags_horizontal = 3
+script = ExtResource("1_h0lnd")
+
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+bbcode_enabled = true
+fit_content = true
+scroll_active = false

--- a/addons/very-simple-twitch/dock/vst-dock.tscn
+++ b/addons/very-simple-twitch/dock/vst-dock.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://m77ohpfa7qef"]
 
-[ext_resource type="Script" path="res://addons/very-simple-twitch/chat/vst_chat_dock.gd" id="1_vxn3l"]
+[ext_resource type="Script" path="res://addons/very-simple-twitch/dock/vst-dock.gd" id="1_kyfdh"]
 
 [node name="vst-dock" type="Control"]
 layout_mode = 3
@@ -9,7 +9,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_vxn3l")
+script = ExtResource("1_kyfdh")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1

--- a/addons/very-simple-twitch/dock/vst-dock.tscn
+++ b/addons/very-simple-twitch/dock/vst-dock.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://m77ohpfa7qef"]
 
-[ext_resource type="Script" path="res://addons/very-simple-twitch/dock/vst-dock.gd" id="1_db1w4"]
+[ext_resource type="Script" path="res://addons/very-simple-twitch/chat/vst_chat_dock.gd" id="1_vxn3l"]
 
 [node name="vst-dock" type="Control"]
 layout_mode = 3
@@ -9,7 +9,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_db1w4")
+script = ExtResource("1_vxn3l")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1

--- a/addons/very-simple-twitch/twitch_chat.gd
+++ b/addons/very-simple-twitch/twitch_chat.gd
@@ -1,3 +1,4 @@
+@tool
 extends Node
 
 class_name TwitchChat

--- a/addons/very-simple-twitch/vst.gd
+++ b/addons/very-simple-twitch/vst.gd
@@ -2,6 +2,7 @@
 extends EditorPlugin
 
 var dock
+var chat_dock
 
 func _enter_tree() -> void:
 	add_custom_type("VerySimpleTwitchChat", "Node", preload("twitch_chat.gd"), preload("icon.png"))
@@ -10,8 +11,15 @@ func _enter_tree() -> void:
 	add_autoload_singleton("VerySimpleTwitch", "twitch_node.gd")
 	
 	TwitchSettings.add_settings()
+	
+	#Bottom setup dock
 	dock = preload("res://addons/very-simple-twitch/dock/vst-dock.tscn").instantiate()
 	add_control_to_bottom_panel(dock, "Very Simple Twitch")
+	
+	#Chat dock
+	chat_dock = preload("res://addons/very-simple-twitch/chat/vst_chat_dock.tscn").instantiate()
+	add_control_to_dock(EditorPlugin.DOCK_SLOT_RIGHT_UL, chat_dock)
+
 
 func _exit_tree() -> void:
 	remove_custom_type("VerySimpleTwitchChat")
@@ -23,3 +31,6 @@ func _exit_tree() -> void:
 	
 	remove_control_from_bottom_panel(dock)
 	dock.free()
+
+	remove_control_from_docks(chat_dock)
+	chat_dock.free()


### PR DESCRIPTION
# Why
It's super cool to have twitch chat integrated into the Godot editor itself, isn't it? It's not only useful for streamers but also as a "usage" example and, if that's not enough, as a debug for future developments where you need to see (without using a console print) the commands or what people type in chat.

# How
It's a simple editor plugin where the messages are displayed as in the example with some changes:

* The chat is ONLY in anonymous mode
* A button has been added to clean up the chat
* A message limit has been added so as not to overload the editor with nodes
* Also added a crude (ok, maybe it's shabby) disconnect ( possible next new feature? )

# Usage
Just add the plugin as always. Navigate to Project -> Plugins -> Very simple twitch chat -> Enable and see at the right dock a new tab with the name "VstChatDock". Write the name of a channel and click connect. The messages will show as soon as the plugin will connect.

# Tests
Manual tests using some twitch random channels and added the plugin in a personal project to see the installation.

# Tasks related
None. Maybe this can be used as discussion?