### PR TITLE
Added community files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RothioTome

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Funding
+# https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository
+
+github: rothiotome
+ko_fi: rothiotome
+custom: ["https://www.twitch.tv/rothiotome/", "https://rothiotome.itch.io/"]

--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a problem you encountered
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to complete this bug report!
+  - type: input
+    id: project
+    attributes:
+      label: Project Version
+      description: Which project version is affected?
+      placeholder: "0.1, 1.0, 2.0.0"
+    validations:
+      required: true
+  - type: input
+    id: existing-issues
+    attributes:
+      label: Similar Issues
+      description: Are there any similar issues reported yet?
+      placeholder: "#1"
+    validations:
+      required: false
+  - type: textarea
+    id: what-is-going-on
+    attributes:
+      label: What is the issue?
+      description: Please add some information about the issue ( usefull for discursions )
+      placeholder: I found the id of menu is misspelled as manu
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1. 
+        2. 
+        3. 
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: What should have happened?
+      placeholder: I tap on menu button and nothing happened
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+      placeholder: If I tap on menu button I expect see the menu opened
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Failure logs or additional information
+      description: Please include code snippets, stack traces or compiler errors here.
+      placeholder: Paste code snippets, stack traces, and compiler errors here
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/request_feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature_template.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Request a new feature for VST
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to complete this feature request!
+  - type: textarea
+    id: description-feature
+    attributes:
+      label: Description
+      description: Please describe the feature and why this will be usefull for the project
+      placeholder: I think is usefull add some sparks at clicking. Sparks are nice :)
+    validations:
+      required: true
+  - type: textarea
+    id: current-feature
+    attributes:
+      label: Current Behavior
+      description: What is the current behavior?
+      placeholder: There is no feedback and sometimes is not clear if an action is happened
+    validations:
+      required: false
+  - type: textarea
+    id: how-feature
+    attributes:
+      label: How
+      description: Describe with your own words (if you can) how can this be archieved for you or another contributor :)
+      placeholder: Use magic
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## 1. Why?
+
+_Please describe why you are requesting the merge_
+
+## 2. How?
+
+_Please describe how you make the changes and why_
+
+## 3. Related Issue
+
+_Is a related issue? use the #numberOfIssue to link it_
+
+## 4. Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## 5. Tests made (if appropriate)
+
+_Describe the tests and the files if you put some_
+
+## 6. Notes (if appropriate)
+
+_Add addtional notes o infomation for this merge if yout needed_

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+rothiotome@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+﻿# Contributing
+
+Thank you for considering contributing to "VST" Godot Very Simple Twitch! 💜
+
+You can contributing to this proyect in the following ways:
+
+* Finding and reporting bugs or issues using the [GitHub Issues](https://github.com/rothiotome/godot-very-simple-twitch/issues) section.
+* Contributing code by fixing bugs, issues or improving the proyect implementing new features.
+
+## Bug reporting
+
+Before submit a bug, please make sure that you are using the latest version of "VST" Godot Very Simple Twitch. If the bug persists, check if the bug is submitted to [GitHub Issues](https://github.com/rothiotome/godot-very-simple-twitch/issues).
+
+When you're submitting the bug, please follow the instructions in the [Issue template](https://github.com/rothiotome/godot-very-simple-twitch/issues/new?assignees=&labels=&projects=&template=bug_report.md)
+
+## Submitting pull request
+
+"VST" Godot Very Simple Twitch code conventions are based on [Godot GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html). Please, follow this guides before contributing.
+
+Before submit a pull request, please make sure that your funcionality is not implemented in other [GitHub Pull request](https://github.com/rothiotome/godot-very-simple-twitch/pulls).
+
+Always write a clear message in your commits. In this proyect we use a format based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so it should look like this:
+
+```bash
+git commit -m "feat: a brief summary of the feature"
+```
+
+When you're submitting the pull request, please follow the instructions in the Pull request template.
+
+---
+
+Thanks for your interest in contributing!♥️

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+﻿# Security Policy
+
+If you discover a security issue, please bring it to our attention right away!
+
+## Reporting a Vulnerability
+ 
+Please **DO NOT** file a public issue to report a security vulberability, instead send your report privately to **rothiotome@gmail.com**. This will help ensure that any vulnerabilities that are found can be [disclosed responsibly](https://en.wikipedia.org/wiki/Responsible_disclosure) to any affected parties.
+
+## Supported Versions
+
+Project versions that are currently being supported with security updates vary per project.
+Please see specific project repositories for details.
+If nothing is specified, only the latest major versions are supported.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,27 @@
+# Support and Help
+
+Need help getting started or using VST? Here's how.
+
+## How to get help
+
+Generally, we do not use GitHub as a support forum. For any usage questions that are not specific to the project itself, please ask on [Stack Overflow](https://stackoverflow.com) instead or reading the docs currently the use its very straigh foward. By doing so, you are more likely to quickly solve your problem, and you will allow anyone else with the same question to find the answer. This also allows maintainers to focus on improving the project for others.
+
+Please seek support in the following ways:
+
+1. :book: **Read the documentation and other guides** for the project to see if you can figure it out on your own. These should be located in a root `docs/` directory or in README file. There is also an example project, explore that to learn how it works to see if you can answer your question.
+
+1. :bulb: **Search for answers and ask questions on [Stack Overflow](https://stackoverflow.com).** This is the most appropriate place for debugging issues specific to your use of the project, or figuring out how to use the project in a specific way.
+
+1. :memo: As a **last resort**, you may open an issue on GitHub to ask for help. However, please clearly explain what you are trying to do, and list what you have already attempted to solve the problem. Provide code samples, but **do not** attach your entire project for someone else to debug. Review our [contributing guidelines](https://github.com/rothiotome/godot-very-simple-twitch/main/CONTRIBUTING.md).
+
+## What NOT to do 
+
+Please **do not** do any the following:
+
+1. :x: Do not reach out to the author or contributor on Twitter (or other social media) by tweeting or sending a direct message. Please don't.
+
+1. :x: Do not email the author or contributor.
+
+1. :x: Do not open duplicate issues or litter an existing issue with +1's.
+
+These are not appropriate avenues for seeking help or support with an open-source project. Please follow the guidelines in the previous section. Public questions get public answers, which benefits everyone in the community. ✌️


### PR DESCRIPTION
# Why
The repo left some community files like codeowners, code of conduct and files like that. Seeing a repo with these files makes the repo more "profresionalish?". It's cool have some of these

# How
So, in this PR I added the following files which are listed on the task BUT I added some extra for juciness ;)

* 2 templates for posting issues: 1 for bugs and 1 for request features
* A codewoner file
* A funding file 
* A pull request template with a form
* A code of conduct file
* A contributing file
* A support file
* A security file

Some of them are modified copies from various repositories ( which I don't remmember the users :( ) and the others are created by the github tool.

# Usage
Most of them are used by github automatically. Only the funding one needs a check on the repo config by the admin repo for full activation. The check are located at "repo settings" -> General -> Features -> Sponsorships  

See more information https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository for enable the button


# Tests
Checked and tested on a private repository.

# Tasks related
#2 