### PR TITLE
Create release-action

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -1,0 +1,23 @@
+name: Create release
+
+on:
+  push:
+    tags: 
+      - v[0-9]+.[0-9]+.*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Zip Folder
+      run: zip -r ${{ github.event.repository.name }}.zip -r --include="./addons/*" .
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ github.event.repository.name }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
⚠️ This functionality needs extra work from repo admin. See notes below⚠️ 

# Why
The plugin for godot is not deployable and you must download all the project only for the plugin with all the data. With this, someone can download the addon without checkout all the repo and files you don't need. This action does not interfere with uploading the plugin at the addon shop at godot and its a cool way to add versioning to the project

# How
Jusst added a github action in a tag push with 2 steps
1. Checkout the last version of main
2. Zip "addon" folder

Keep in mind this will not work unless a ACTION_TOKEN is set ( action will fail like 3 times ). See the notes below

# Usage
The action is configured to raise on tags with the following pattern: "v{number}.{number}.{any}. The idea is when a release candidate is ready to deploy push a tag and github action create the release zip for anyone. 

This release also could be tracked for badges and will appear at the rigth section of the main repo page.

# Notes
For let github action use the repo you need add a token named "ACCESS_TOKEN" in the repo with "**repo and workflow**" privileges. This token must be private so keep away from people.

Create a token flow: "profile settings" -> "developer settings" -> "personal access token"
Add a secret token flow: "repo settings" -> "secrets and variables" -> "actions" -> Repository secrets

See more information-> https://docs.github.com/en/enterprise-server@3.9/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens

# Tests
Checked and tested on a private repository.

# Tasks related
#4