### PR TITLE
Fix height 0 bug on Dock

### DIFF
--- a/addons/very-simple-twitch/dock/vst-dock.tscn
+++ b/addons/very-simple-twitch/dock/vst-dock.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/very-simple-twitch/dock/vst-dock.gd" id="1_kyfdh"]
 
-[sub_resource type="Image" id="Image_ctdkn"]
+[sub_resource type="Image" id="Image_71us6"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -11,11 +11,10 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_rmgw5"]
-image = SubResource("Image_ctdkn")
+[sub_resource type="ImageTexture" id="ImageTexture_wkb3q"]
+image = SubResource("Image_71us6")
 
-[node name="vst-dock" type="Control"]
-layout_mode = 3
+[node name="vst-dock" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,24 +22,16 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_kyfdh")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="HelpIcon" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
+[node name="HelpIcon" type="TextureRect" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-texture = SubResource("ImageTexture_rmgw5")
+texture = SubResource("ImageTexture_wkb3q")
 stretch_mode = 5
 
-[node name="RichTextLabel2" type="RichTextLabel" parent="VBoxContainer/HBoxContainer"]
+[node name="RichTextLabel2" type="RichTextLabel" parent="HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 focus_mode = 2
@@ -50,24 +41,24 @@ text = " [url=https://github.com/rothiotome/godot-very-simple-twitch?tab=readme-
 fit_content = true
 selection_enabled = true
 
-[node name="Label" type="Label" parent="VBoxContainer"]
+[node name="Label" type="Label" parent="."]
 layout_mode = 2
 text = "Quick Start Guide"
 
-[node name="RedirectURI" type="HBoxContainer" parent="VBoxContainer"]
+[node name="RedirectURI" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/RedirectURI"]
+[node name="Label" type="Label" parent="RedirectURI"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Redirect URI: "
 
-[node name="RedirectURIContainer" type="HBoxContainer" parent="VBoxContainer/RedirectURI"]
+[node name="RedirectURIContainer" type="HBoxContainer" parent="RedirectURI"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
-[node name="RedirectURI" type="RichTextLabel" parent="VBoxContainer/RedirectURI/RedirectURIContainer"]
+[node name="RedirectURI" type="RichTextLabel" parent="RedirectURI/RedirectURIContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -76,45 +67,45 @@ text = "Value"
 fit_content = true
 selection_enabled = true
 
-[node name="CopyButton" type="Button" parent="VBoxContainer/RedirectURI/RedirectURIContainer"]
+[node name="CopyButton" type="Button" parent="RedirectURI/RedirectURIContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Copy Redirect URL to clipboard"
-icon = SubResource("ImageTexture_rmgw5")
+icon = SubResource("ImageTexture_wkb3q")
 
-[node name="ClientID" type="HBoxContainer" parent="VBoxContainer"]
+[node name="ClientID" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/ClientID"]
+[node name="Label" type="Label" parent="ClientID"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Client ID:"
 
-[node name="ClientIDLineEdit" type="LineEdit" parent="VBoxContainer/ClientID"]
+[node name="ClientIDLineEdit" type="LineEdit" parent="ClientID"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 placeholder_text = "YOUR CLIENT ID HERE"
 
-[node name="Warning" type="HBoxContainer" parent="VBoxContainer"]
+[node name="Warning" type="HBoxContainer" parent="."]
 layout_mode = 2
 alignment = 1
 
-[node name="WarningIcon" type="TextureRect" parent="VBoxContainer/Warning"]
+[node name="WarningIcon" type="TextureRect" parent="Warning"]
 unique_name_in_owner = true
 layout_mode = 2
-texture = SubResource("ImageTexture_rmgw5")
+texture = SubResource("ImageTexture_wkb3q")
 stretch_mode = 5
 
-[node name="ClientIDWarning" type="Label" parent="VBoxContainer/Warning"]
+[node name="ClientIDWarning" type="Label" parent="Warning"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_colors/font_color = Color(0.72, 0.61, 0.48, 1)
 text = "To use VST, you need a Client ID. Check the readme above for how to get one."
 
-[connection signal="meta_clicked" from="VBoxContainer/HBoxContainer/RichTextLabel2" to="." method="open_url"]
-[connection signal="pressed" from="VBoxContainer/RedirectURI/RedirectURIContainer/CopyButton" to="." method="copy_redirect_uri"]
-[connection signal="focus_exited" from="VBoxContainer/ClientID/ClientIDLineEdit" to="." method="client_id_submitted"]
-[connection signal="text_submitted" from="VBoxContainer/ClientID/ClientIDLineEdit" to="." method="client_id_submitted" unbinds=1]
+[connection signal="meta_clicked" from="HBoxContainer/RichTextLabel2" to="." method="open_url"]
+[connection signal="pressed" from="RedirectURI/RedirectURIContainer/CopyButton" to="." method="copy_redirect_uri"]
+[connection signal="focus_exited" from="ClientID/ClientIDLineEdit" to="." method="client_id_submitted"]
+[connection signal="text_submitted" from="ClientID/ClientIDLineEdit" to="." method="client_id_submitted"]


### PR DESCRIPTION
## 1. Why?

The first time I opened the Dock it had a height of 0. It looked like this:
![photo_2024-06-28_16-03-01](https://github.com/rothiotome/godot-very-simple-twitch/assets/8767085/d78666a3-ef3e-4764-93ba-27614ae2436f)

It can still be resized to be taller, but it can also be shrunk to 0 pixels again. Apparently Godot doesn't like the root node being a Control, since it cannot tell what its height is.

## 2. How?

Make the (already existing) VBoxContainer the root node of the Dock scene. That way Godot knows what its current height is and it can be resized without issue.

This is how it goes with the smallest possible resolution Godot allows me to set:
![image](https://github.com/rothiotome/godot-very-simple-twitch/assets/8767085/ff48e4a1-0055-44e5-9703-d39e20a575a9)

The original note also had a script and some signals connecting to it. I also moved them, so now it's the VBoxContainer the one with the script and the signals connected.

## 3. Related Issue

n/a

## 4. Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

After making the change and reloading the editor, tested manually:

- Resize Godot's window, stretching and squashing the window horizontally and vertically.
- Resize the Dock, stretching and squashing it vertically.
- Click the copy "Redirect URI" and check it's in the clipboard (it can be pasted with ctrl+v).

## 6. Notes (if appropriate)

n/a