### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Easily connect your Godot games to Twitch chat. Log in with a single line of cod
 Godot Very Simple Twitch requires Godot 4.2 or higher. You can check the Godot version you have installed in the bottom dock or your editor.
 - Clone the project or download last release.
 - If you cloned the project, extract the ```addons``` folder
-- Move the ```addons``` fodler to your game folder
+- Move the ```addons``` folder to your game folder
 
 To verify the installation is correct:
 - The folder path ```res://addons/very-simple-twitch``` exists

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ VerySimpleTwitch.get_token_and_login_chat()
 To receive the Twitch chat messages, connect the `chat_message_received` signal from VerySimpleTwitch. The signal contains all the information available from the chatter, including display_name, badges, tags and colors.
 ```GDScript
 func _ready():
-	VerySimpleTwitch.chat_message_received.connect(print_chatter_msg)
+	VerySimpleTwitch.chat_message_received.connect(print_chatter_message)
 
 func print_chatter_message(chatter: Chatter):
-	print("Message received from %s: %s % [chatter.tags.display_name, escape_bbcode(chatter.message)])
+	print("Message received from %s: %s" % [chatter.tags.display_name, chatter.message])
 ```
 
 ## How to send chat messages


### PR DESCRIPTION
## 1. Why?

There are a couple of things wrong in the README, mostly with the receive messages example: 

- When connecting the signal, it references `print_chatter_msg` but the function declared below is named `print_chatter_message`
- The string in the print is unterminated
- It uses a function called `escape_bbcode`, which exists in the example project but it might not be straightforward.

## 2. How?

- Use `print_chatter_message` in both lines of code.
- Add missing `"` to the string.
- Remove call to `escape_bbcode` so the example is more clear.

## 3. Related Issue

n/a

## 4. Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

n/a

## 6. Notes (if appropriate)

n/a