### PR TITLE
Hotfix: Plugin is not initializated properly + Update godot 4.3

### DIFF
--- a/addons/very-simple-twitch/twitch_chat_settings.gd
+++ b/addons/very-simple-twitch/twitch_chat_settings.gd
@@ -93,13 +93,15 @@ static func add_settings():
 	for setting in settings:
 		var setting_value = settings[setting]
 		var path = "very_simple_twitch/"+ setting_value.get("path", "config" +setting)
-		ProjectSettings.set_setting(path, setting_value.get("initial_value"))
+		var saved_value = ProjectSettings.get_setting(path)
+		if !saved_value:
+			ProjectSettings.set_setting(path, setting_value.get("initial_value"))
 		var property_info = {
 			"name": path,
 			"type": setting_value.get("type",  typeof(setting_value.get("initial_value"))),
 			"hint": setting_value.get("hint"),
 			"hint_string": setting_value.get("hint_string", "")
-	}
+		}
 		ProjectSettings.set_as_basic(path,  setting_value.get("is_basic", true))
 		ProjectSettings.set_initial_value(path, setting_value.get("initial_value"))
 		ProjectSettings.add_property_info(property_info)

--- a/icon.png.import
+++ b/icon.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dcdcsvegs7vr2"
+uid="uid://30f5rko4a6aj"
 path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot Very Simple Twitch"
 run/main_scene="res://example/Demo.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 
 [autoload]


### PR DESCRIPTION
## 1. Why?

When the plugin was initialized, all settings were overwritten to the initial value regardless of the data stored in the project settings (the data storage). That happens everytime the plugin was loaded ( starting godot, reloading the plugin... )

## 2. How?

Now it is checked if there is a data saved in order to no overwrite it with the initial value

## 3. Related Issue

#22 

## 4. Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

Used the main project and a test one

## 6. Notes (if appropriate)

I take this merge oportunity to upload the version to godot 4.3 (which is a really easy change)