### PR TITLE
fix 2x + timeout message timing

### DIFF
--- a/addons/very-simple-twitch/twitch_chat.gd
+++ b/addons/very-simple-twitch/twitch_chat.gd
@@ -49,7 +49,7 @@ func _process(_delta: float):
 				onChatConnected()
 			while _chatClient.get_available_packet_count():
 				onReceivedData(_chatClient.get_packet())
-			if !_chat_queue.is_empty() and _last_msg + (_last_msg + _chat_timeout_ms) <= Time.get_ticks_msec():
+			if !_chat_queue.is_empty() and (_last_msg + _chat_timeout_ms) <= Time.get_ticks_msec():
 				_chatClient.send_text(_chat_queue.pop_front())
 				_last_msg = Time.get_ticks_msec()
 		WebSocketPeer.STATE_CLOSED:


### PR DESCRIPTION
Fixes the send_text loop so that the wait time to send does not get longer the longer you use the app

## 1. Why?

As it stands now, the first message will send instantly, and then every subsequent message will be 2*_last_msg + _chat_timeout_ms. 

## 2. How?

The conditional should check if the time elapsed is the time since last message plus the chat timeout, not last message + last message + timeout. I just removed the first _last_message.

## 3. Related Issue

No.

## 4. Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

N/A

## 6. Notes (if appropriate)

N/A