### PR TITLE
Is connected signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ func print_chatter_message(chatter: Chatter):
 ## How to send chat messages
 To send chat messages, you can use the ``VerySimpleTwitch.send_chat_message("Hello world")`` static method. Sending chat messages is only available when you use the OAuth connection method with a Token that has writing permissions.
 
+## How test conneciton
+
+To ensure you are connected to the Twitch channel, you can use the ```VerySimpleTwitch.is_connected_to_server(callable)```. method. This method will pass`true` or `false`, depending on whether the plugin is connected to the Twitch channel through callable.
+
 ## How to Logout
 To log out from an already connected Twitch Channel, you can use the method ``VerySimpleTwitch.end_chat_client()`` to stop the connection. This method is useful if the user misspelled their channel name with Anonymous connection or wants to change accounts / stop the integration.
 

--- a/addons/very-simple-twitch/twitch_chat.gd
+++ b/addons/very-simple-twitch/twitch_chat.gd
@@ -120,6 +120,7 @@ func send_ping():
 	if last_ping_unix_time+TIME_BETWEEN_PING_IN_SECONDS >= Time.get_unix_time_from_system():
 		is_connected_to.emit(last_ping_response) # return last response avoiding the flood
 		return
+	# timer for timeout will raise allways and check the status before
 	var timer = get_tree().create_timer(TIMEOUT_PING_IN_SECONDS)
 	timer.timeout.connect(_raise_last_ping_signal.bind(false))
 	_chatClient.send_text("PING :tmi.twitch.tv")
@@ -304,6 +305,8 @@ func disconnect_api():
 	_hasConnected = false
 
 func _raise_last_ping_signal(result:bool):
+	# This method can be called by timer timeout or by mistake, check the status
+	# and only modify, change values if we are in that window
 	if last_ping_unix_time+TIME_BETWEEN_PING_IN_SECONDS >= Time.get_unix_time_from_system(): return
 	last_ping_unix_time = Time.get_unix_time_from_system()
 	last_ping_response = result

--- a/addons/very-simple-twitch/twitch_node.gd
+++ b/addons/very-simple-twitch/twitch_node.gd
@@ -69,3 +69,15 @@ func send_chat_message(message: String):
 
 func on_chat_message_received(chatter: VSTChatter):
 	chat_message_received.emit(chatter)
+
+
+func is_connected_to_server(callable:Callable):
+	if !_twitch_chat: 
+		callable.bind(false).call() 
+		return
+	if !_twitch_chat._hasConnected: 
+		callable.bind(false).call() 
+		return
+	if _twitch_chat.is_connected_to.is_connected(callable): return
+	_twitch_chat.is_connected_to.connect(callable, CONNECT_ONE_SHOT)
+	_twitch_chat.send_ping()

--- a/addons/very-simple-twitch/twitch_node.gd
+++ b/addons/very-simple-twitch/twitch_node.gd
@@ -72,12 +72,14 @@ func on_chat_message_received(chatter: VSTChatter):
 
 
 func is_connected_to_server(callable:Callable):
+	# first and naive checks for connection status
 	if !_twitch_chat: 
 		callable.bind(false).call() 
 		return
 	if !_twitch_chat._hasConnected: 
 		callable.bind(false).call() 
 		return
+	# if is connected already, will response later. Don't care this call
 	if _twitch_chat.is_connected_to.is_connected(callable): return
 	_twitch_chat.is_connected_to.connect(callable, CONNECT_ONE_SHOT)
 	_twitch_chat.send_ping()

--- a/example/Demo.tscn
+++ b/example/Demo.tscn
@@ -138,6 +138,11 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Clear chat"
 
+[node name="TestConnection" type="Button" parent="VBoxContainer/LoggedLayout"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Test Connection"
+
 [node name="ConnectedLabel" type="Label" parent="VBoxContainer"]
 unique_name_in_owner = true
 visible = false
@@ -157,3 +162,4 @@ size_flags_vertical = 3
 [connection signal="pressed" from="VBoxContainer/TabContainer/Anonymous Connection/MarginContainer/AnonymousConnectionLayout/LoginChat/LoginAnon" to="." method="login_anon"]
 [connection signal="pressed" from="VBoxContainer/LoggedLayout/LogoutButton" to="." method="logout"]
 [connection signal="pressed" from="VBoxContainer/LoggedLayout/ClearChar" to="." method="clear_chat"]
+[connection signal="pressed" from="VBoxContainer/LoggedLayout/TestConnection" to="." method="_on_test_connection_pressed"]

--- a/example/demo.gd
+++ b/example/demo.gd
@@ -13,6 +13,10 @@ func logout():
 	%TwitchChat.clear()
 	_show_login_layout()
 
+func _on_test_connection_pressed() -> void:
+	VerySimpleTwitch.is_connected_to_server(func (connection_result):
+		print("Connected? -> %s" % str(connection_result))
+	)
 
 #region Local methods to simplify demo
 func _show_login_layout():


### PR DESCRIPTION
## 1. Why?

There is new feature described in #30 in order to check if plugin is connected or not

## 2. How?

Added a new signal to TwitchChat and now you can send a ping to ensure a connection to IRC.  The value and timestamp were saved for further checks to avoid flooding the Twitch server. 

Check TIMEOUT_PING_IN_SECONDS adn TIME_BETWEEN_PING_IN_SECONDS constants in TwtichChat.gd for "time spacer" values

NOTE: Why is a timesamp and not a millisecond tick based value? I think this is worth because you can also show when, in a human readeable way, last test was.

## 3. Related Issue

#30

## 4. Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

Manual test were made using the demo app, no unit test added
