### PR TITLE
Feature: Reconnect to chat

### DIFF
--- a/addons/very-simple-twitch/twitch_chat_settings.gd
+++ b/addons/very-simple-twitch/twitch_chat_settings.gd
@@ -86,6 +86,20 @@ const settings: Dictionary = {
 		"hint_string": "Time between messages sent by the client",
 		"is_basic": false,
 		"initial_value": 320,
+	},
+	"max_tries_reconnect":{
+		"path": "advanced_config/max_tries_reconnect",
+		"type:": TYPE_INT,
+		"hint_string": "Maximum times it will attempt to reconnect",
+		"is_basic": false,
+		"initial_value": 3,
+	},
+	"time_reconnect":{
+		"path": "advanced_config/time_reconnect",
+		"type:": TYPE_INT,
+		"hint_string": "Time in seconds between reconnections",
+		"is_basic": false,
+		"initial_value": 5,
 	}
 }
 


### PR DESCRIPTION
⚠️⚠️ IT'S A DRAFT REQUEST ⚠️⚠️ SEE COMMENTS BELOW ⚠️⚠️

## 1. Why?

If the conection fails for some reason we need a way to reconnect the plugin itself a fixed amount of times.

## 2. How?

Added 2 new variables to settings one for connection retries and the other for waiting time. If the plugin fails to connect to server ( api or chat ) tries to reconnect using timers.

## 3. Related Issue

#16 

## 4. Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

waiting for advice
