### PR TITLE
FIX: user-id instead of room-id

### DIFF
--- a/addons/very-simple-twitch/parse_helper.gd
+++ b/addons/very-simple-twitch/parse_helper.gd
@@ -33,7 +33,7 @@ static func parse_tags(input_string:String) -> VSTIRCTags:
 				irc_tags.display_name = splitted_tag[1]
 			"emotes":
 				irc_tags.emotes = parse_emotes(splitted_tag[1].split("/"))
-			"room-id":
+			"user-id":
 				irc_tags.user_id = splitted_tag[1]
 
 	return irc_tags


### PR DESCRIPTION
## 1. Why?

Bug existed wherein the user tags was returning the room-id for every unique user, not their user-id.

## 2. How?

I corrected switch/case to use `user-id` in place of `room-id`

## 3. Related Issue

No related issue.

## 4. Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 5. Tests made (if appropriate)

Manual testing while fixing my bot locally to properly handle user ids.
