### PR TITLE
get_token_and_login_chat() now takes an optional `channel` parameter indicating which channel to connect to

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Easily connect your Godot games to Twitch chat. Log in with a single line of cod
 		- [Usage](#usage)
 		- [Features](#features)
 		- [Modifications](#modifications)
+- [Exporting the project](#exporting-the-project)
 - [FAQ and Troubleshooting](#faq-and-troubleshooting)
 	- [Change Settings](#change-settings)
 - [License](#license)
@@ -88,6 +89,12 @@ VerySimpleTwitch.get_token_and_login_chat()
 
 > Note: You will need to set up the CLIENT_ID in the Settings tab and configure the Twitch app accordingly.
 
+Optionally you can log in to a specific channel by passing the channel name as a parameter.
+
+```GDScript
+VerySimpleTwitch.get_token_and_login_chat("channel_name")
+```
+
 ## How to receive chat messages
 To receive Twitch chat messages, connect the `chat_message_received` signal from VerySimpleTwitch. The signal contains all the information available from the chatter, including display_name, badges, tags, and colors.
 
@@ -124,6 +131,10 @@ Just add and activate the plugin as explained in the installation instructions. 
 - The chat dock works ONLY in anonymous mode, so you don't need any authorization token, just the channel name.
 - There is a limit for saved messages. The default is 50 messages, but it can be changed in the editor settings (TBI).
 - You can delete all chat messages.
+
+## Exporting the project
+
+In order for the plugin to work properly when exported `addons/very-simple-twitch/public/index.html` needs to be included in the export, check your Filters to export non-resource files/folders under the `Resources` tab of the export preset dialog.
 
 ## FAQ and Troubleshooting
 ### Change Settings

--- a/addons/very-simple-twitch/twitch_node.gd
+++ b/addons/very-simple-twitch/twitch_node.gd
@@ -18,10 +18,13 @@ func login_chat(channel_info: VSTChannel):
 	_twitch_chat.login(channel_info)
 	chat_connected.emit(await _twitch_chat.Connected)
 
-
-func get_token_and_login_chat():
-	var channel_info =  await get_token()
-	await login_chat(channel_info)
+## Fetches token and logins to `channel`, if no channel is provided it will default to the token holder's channel
+func get_token_and_login_chat(channel := ""):
+	var target_channel := await get_token()
+	if channel != "":
+		target_channel = VSTChannel.new()
+		target_channel.login = channel
+	await login_chat(target_channel)
 
 
 func _start_chat_client():


### PR DESCRIPTION
get_token_and_login_chat() now takes an optional `channel` parameter indicating which channel to connect to, if no channel name is provided it will connect to the token holder's channel by default (preserving backwards compatibility)

## Related Issue

#43